### PR TITLE
windows: Avoid depending on min() macro.

### DIFF
--- a/c/windows.c
+++ b/c/windows.c
@@ -56,7 +56,8 @@ int get_os_release(char *outbuf, size_t outlen) {
 
   // If the output buffer is smaller than the version (or "unknown"),
   // we only wrote until the buffer was full.
-  return min(written, (int)outlen - 1);
+  int maxsize = (int)outlen - 1;
+  return written < maxsize ? written : maxsize;
 }
 
 /**


### PR DESCRIPTION
I'm trying to enable c++20 in Gecko, and for $reasons we need to include mozilla-config.h, see
https://bugzilla.mozilla.org/show_bug.cgi?id=1992321

That file defines NOMINMAX, which causes windows.h to not define the min() and max() macros.

Just don't rely on the min() macro here.